### PR TITLE
Try to get a name from a longer string.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -706,6 +706,9 @@ class Fedora(callbacks.Plugin):
         if not recip:
             return
 
+        # Extract 'puiterwijk' out of 'have a cookie puiterwijk++'
+        recip = recip.strip().split()[-1]
+
         increment = direction == '++' # If not, then it must be decrement
 
         # Check that these are FAS users


### PR DESCRIPTION
Earlier today, pingou tried:

```
14:21:04     pingou │ have a cookie: puiterwijk++
```

But nothing happened.  In the logs, we got:

```
Saw 'have a cookie: puiterwijk' from pingou, but 'have a cookie: puiterwijk' not in FAS
```