### PR TITLE
Adjust the .mirroradmins command for MirrorManager2

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -830,14 +830,14 @@ class Fedora(callbacks.Plugin):
 
         Return MirrorManager list of FAS usernames which administer <hostname>.
         <hostname> must be the FQDN of the host."""
-        url = ("https://admin.fedoraproject.org/mirrormanager/mirroradmins?"
-               "tg_format=json&host=" + hostname)
-        result = self._load_json(url)['values']
-        if len(result) == 0:
-            irc.reply('Hostname "%s" not found' % hostname)
+        url = ("https://admin.fedoraproject.org/mirrormanager/api/"
+               "mirroradmins?name=" + hostname)
+        result = self._load_json(url)
+        if not 'admins' in result:
+            irc.reply(result.get('message', 'Something went wrong')
             return
         string = 'Mirror Admins of %s: ' % hostname
-        string += ' '.join(result)
+        string += ' '.join(result['admins'])
         irc.reply(string.encode('utf-8'))
     mirroradmins = wrap(mirroradmins, ['text'])
 


### PR DESCRIPTION
From the next release (0.2.0) of MirrorManager2, there will be a new API
endpoint dedicated to providing admins of the specified host or site.

This change will not work until this new release is done, but that will
not change anything from the current situation where it does not work
either.