### PR TITLE
When querying for karma,transform irc nicks into fas usernames if possible

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -698,6 +698,8 @@ class Fedora(callbacks.Plugin):
         data = None
         try:
             data = shelve.open(self.karma_db_path)
+            if name in self.nickmap:
+                name = self.nickmap[name]
             votes = data['backwards'].get(name, {})
         finally:
             if data:


### PR DESCRIPTION
This aligns the behavior with that of providing karma with ++ or --.

Addresses #37

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fedora-infra/supybot-fedora/38)
<!-- Reviewable:end -->
