### PR TITLE
Keep track of karma per-release.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -176,9 +176,6 @@ class Fedora(callbacks.Plugin):
 
         self.github_oauth_token = self.registryValue('github.oauth_token')
 
-        self.karma_db_path = self.registryValue('karma.db_path')
-        self.allow_unaddressed_karma = self.registryValue('karma.unaddressed')
-        self.allow_negative = self.registryValue('karma.allow_negative')
         self.karma_tokens = ('++', '--') if self.allow_negative else ('++',)
 
         # fetch necessary caches
@@ -231,6 +228,18 @@ class Fedora(callbacks.Plugin):
         self._refresh()
         irc.replySuccess()
     refresh = wrap(refresh)
+
+    @property
+    def karma_db_path(self):
+        return self.registryValue('karma.db_path')
+
+    @property
+    def allow_unaddressed_karma(self):
+        return self.registryValue('karma.unaddressed')
+
+    @property
+    def allow_negative(self):
+        return self.registryValue('karma.allow_negative')
 
     def _load_json(self, url):
         timeout = socket.getdefaulttimeout()

--- a/plugin.py
+++ b/plugin.py
@@ -809,42 +809,43 @@ class Fedora(callbacks.Plugin):
         data = None
         try:
             data = shelve.open(self.karma_db_path)
+            fkey = 'forwards-' + release
+            bkey = 'backwards-' + release
+            if fkey not in data:
+                data[fkey] = {}
 
-            if 'forwards-' + release not in data:
-                data['forwards-' + release] = {}
+            if bkey not in data:
+                data[bkey] = {}
 
-            if 'backwards-' + release not in data:
-                data['backwards-' + release] = {}
-
-            if agent not in data['forwards-' + release]:
-                forwards = data['forwards-' + release]
+            if agent not in data[fkey]:
+                forwards = data[fkey]
                 forwards[agent] = {}
-                data['forwards-' + release] = forwards
+                data[fkey] = forwards
 
-            if recip not in data['backwards-' + release]:
-                backwards = data['backwards-' + release]
+            if recip not in data[bkey]:
+                backwards = data[bkey]
                 backwards[recip] = {}
-                data['backwards-' + release] = backwards
+                data[bkey] = backwards
 
             vote = 1 if increment else -1
 
-            if data['forwards-' + release][agent].get(recip) == vote:
+            if data[fkey][agent].get(recip) == vote:
                 ## People found this response annoying.
                 ## https://github.com/fedora-infra/supybot-fedora/issues/25
                 #irc.reply(
                 #    "You have already given %i karma to %s" % (vote, recip))
                 return
 
-            forwards = data['forwards-' + release]
+            forwards = data[fkey]
             forwards[agent][recip] = vote
-            data['forwards-' + release] = forwards
+            data[fkey] = forwards
 
-            backwards = data['backwards-' + release]
+            backwards = data[bkey]
             backwards[recip][agent] = vote
-            data['backwards-' + release] = backwards
+            data[bkey] = backwards
 
             # Count the number of karmas for old so-and-so.
-            total = sum(data['backwards-' + release][recip].values())
+            total = sum(data[bkey][recip].values())
         finally:
             if data:
                 data.close()

--- a/plugin.py
+++ b/plugin.py
@@ -774,7 +774,7 @@ class Fedora(callbacks.Plugin):
         # Exclude 'c++', 'g++' or 'i++' (c,g,i), issue #30
         if str(recip).lower() in ['c','g','i']:
             return
-        
+
         increment = direction == '++' # If not, then it must be decrement
 
         # Check that these are FAS users

--- a/plugin.py
+++ b/plugin.py
@@ -845,7 +845,13 @@ class Fedora(callbacks.Plugin):
             data[bkey] = backwards
 
             # Count the number of karmas for old so-and-so.
-            total = sum(data[bkey][recip].values())
+            total_this_release = sum(data[bkey][recip].values())
+
+            total_all_time = 0
+            for key in data:
+                if 'backwards-' not in key:
+                    continue
+                total_all_time += sum(data[key].get(recip, {}).values())
         finally:
             if data:
                 data.close()
@@ -856,7 +862,8 @@ class Fedora(callbacks.Plugin):
             msg={
                 'agent': agent,
                 'recipient': recip,
-                'total': total,
+                'total': total_all_time,  # The badge rules use this value
+                'total_this_release': total_this_release,
                 'vote': vote,
                 'channel': channel,
                 'line': line,
@@ -867,7 +874,8 @@ class Fedora(callbacks.Plugin):
         url = self.registryValue('karma.url')
         irc.reply(
             'Karma for %s changed to %r '
-            '(for the %s release cycle):  %s' % (recip, total, release, url))
+            '(for the %s release cycle):  %s' % (
+                recip, total_this_release, release, url))
 
 
     def wikilink(self, irc, msg, args, name):


### PR DESCRIPTION
We have to be careful when opening the old karma db format that we convert
it correctly to this new format.  After that, we can give karma per-release
as well as report per-release karma (for the current release) as well as
the all-time total per user.

/cc @mattdm