### PR TITLE
Add wiki link command

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,3 @@
-- wiki [[Page name]] snarfer that prints back a link to the wiki (maybe even
-  check for redirects, too)
 - fix ext and fasinfo to report whether a Fedora Talk extension is enabled or
   disabled (not currently possible, the config setting is only readable by
   that user, not anybody)

--- a/plugin.py
+++ b/plugin.py
@@ -439,7 +439,6 @@ class Fedora(callbacks.Plugin):
             branch_list.append(listing['collection']['branchname'])
         branch_list.sort()
         irc.reply(' '.join(branch_list))
-        return
     branches = wrap(branches, ['text'])
 
     def wiki(self, irc, msg, args, page_name):
@@ -451,7 +450,6 @@ class Fedora(callbacks.Plugin):
         # Properly format spaces for the wiki link.
         link.replace(" ", "_")
         irc.reply(link)
-        return
     wiki = wrap(wiki, ['text'])
 
     def what(self, irc, msg, args, package):

--- a/plugin.py
+++ b/plugin.py
@@ -442,6 +442,18 @@ class Fedora(callbacks.Plugin):
         return
     branches = wrap(branches, ['text'])
 
+    def wiki(self, irc, msg, args, page_name):
+        """<wiki_page>
+
+        Return the Fedora wiki link for the specified page."""
+        link = "https://fedoraproject.org/wiki/{}".format(page_name)
+
+        # Properly format spaces for the wiki link.
+        link.replace(" ", "_")
+        irc.reply(link)
+        return
+    wiki = wrap(wiki, ['text'])
+
     def what(self, irc, msg, args, package):
         """<package>
 


### PR DESCRIPTION
This commit adds a `.wiki <page_name>` command, which outputs the correct wiki link for a specified wiki page.

Inspiration: https://github.com/fedora-infra/supybot-fedora/blob/develop/TODO.txt#L1

ex: 
`<user>: .wiki Ambassadors`
`<zodbot>: user: https://fedoraproject.org/wiki/Ambassadors`