### PR TITLE
karma: use release-local in-/decreased numbers

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -828,11 +828,11 @@ class Fedora(callbacks.Plugin):
         dec = len([v for v in votes.values() if v == -1])
         total = inc - dec
 
-        inc, dec = 0, 0
+        alltime_inc = alltime_dec = 0
         for release in alltime:
-            inc += len([v for v in release.values() if v == 1])
-            dec += len([v for v in release.values() if v == -1])
-        alltime_total = inc - dec
+            alltime_inc += len([v for v in release.values() if v == 1])
+            alltime_dec += len([v for v in release.values() if v == -1])
+        alltime_total = alltime_inc - alltime_dec
 
         irc.reply("Karma for %s has been increased %i times and "
                     "decreased %i times this release cycle for a "


### PR DESCRIPTION
.karma would be displaying the alltime increments and decrements because the same variable was reused.
This would cause in a string like: "Karma for puiterwijk has been increased 73 times and decreased 0 times
this release cycle for a total of 44 (73 all time)", which is wrong.

This patch makes it store the alltime increments and decrements in other variables to avoid overwriting
the current-release numbers.