### PR TITLE
Use gender neutral pronoun when timezone not set

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -564,7 +564,7 @@ class Fedora(callbacks.Plugin):
             return
         timezone_name = person['timezone']
         if timezone_name is None:
-            irc.reply('User "%s" doesn\'t share his timezone' % name)
+            irc.reply('User "%s" doesn\'t share their timezone' % name)
             return
         try:
             time = datetime.datetime.now(pytz.timezone(timezone_name))


### PR DESCRIPTION
This pull request just changes one line.

`irc.reply('User "%s" doesn\'t share his timezone' % name)`

…to…

`irc.reply('User "%s" doesn\'t share their timezone' % name)`