### PR TITLE
Fix bugzilla_contact handling from yaml file

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -430,7 +430,7 @@ class Fedora(callbacks.Plugin):
                 if 'bugzilla_contact' in yml:
                     lines = []
                     for k, v in yml['bugzilla_contact'].iteritems():
-                        lines += '%s: %s' % (ircutils.bold(k), v)
+                        lines.append('%s: %s' % (ircutils.bold(k), v))
                     resp += ' - ' + '; '.join(lines)
             except yaml.scanner.ScannerError:
                 # If we can't parse the YAML for some reason, don't worry about


### PR DESCRIPTION
When parsing the bugzilla_contact in yaml files, the data is added the
the lines list.  Using 'lines +=' causes each each character in the
bugzilla_contact string to be added to the lines list, resulting in
lines containing:
```
  ['F', 'e', 'd', 'o', 'r', 'a', ':', ' ', '@', 'k', 'd', 'e', '-', 's', 'i', 'g']
```
rather than the desired:
```
  ['Fedora: @kde-sig']
```
The result from zodbot:
```
  14:43:22 <RaphGro> .whoowns kf5-modemmanager-qt
  14:43:23 <zodbot> RaphGro: owner: dvratil - ; F; e; d; o; r; a; ; :;  ; @; k; d; e; -; s; i; g
```
Thanks to misc (Michael Scherer) in #fedora-devel for helping to locate
the problematic code (and to the supybot-fedora source ;).

Signed-off-by: Todd Zullinger <tmz@pobox.com>