### PR TITLE
fix caching

### DIFF
--- a/supybot_fedora/plugin.py
+++ b/supybot_fedora/plugin.py
@@ -219,7 +219,7 @@ class Fedora(callbacks.Plugin):
             self.users = []
             self.faslist = {}
             self.nickmap = {}
-            for user in self.fasjsonclient.list_all_entities("users"):
+            for user in self.fasjsonclient.list_users().result:
                 name = user["username"]
                 self.users.append(name)
                 key = " ".join(
@@ -227,7 +227,7 @@ class Fedora(callbacks.Plugin):
                         user["username"],
                         user["emails"][0],
                         user["human_name"] or "",
-                        user["ircnicks"][0] or "",
+                        user["ircnicks"][0] or "" if user["ircnicks"] else "",
                     ]
                 )
                 value = "%s '%s' <%s>" % (
@@ -236,7 +236,8 @@ class Fedora(callbacks.Plugin):
                     user["emails"][0] or "",
                 )
                 self.faslist[key] = value
-                for nick in user.get("ircnicks", []):
+                nicks = user.get("ircnicks", []) if user["ircnicks"] else []
+                for nick in nicks:
                     self.nickmap[nick] = name
         else:
             # leave this untouched for now, will remove when FAS finally disappears


### PR DESCRIPTION
previously, we used list_all_entities which was slow, and caused
the stg fasjson to give a 500, since list_users() gives us everything
we need, we now use that instead.

Also, add some checks and backups if the IRC nicks list is None. which
is the case if a user has not defined an IRC nick

Signed-off-by: Ryan Lerch <rlerch@redhat.com>