### PR TITLE
Remove hardcoded calendar URLs

### DIFF
--- a/supybot_fedora/config.py
+++ b/supybot_fedora/config.py
@@ -62,6 +62,14 @@ conf.registerGlobalValue(
     registry.Boolean(True, "Use FasJSON for accounts data rather than FAS"),
 )
 
+conf.registerGlobalValue(
+    Fedora,
+    "fedocal_url",
+    registry.String(
+        "https://calendar.fedoraproject.org/",
+        """URL for fedocal / Fedora Calendar""",
+    ),
+)
 
 # This is where your configuration variables (if any) should go.  For example:
 # conf.registerGlobalValue(Fedora, 'someConfigVariableName',


### PR DESCRIPTION
This removes the hardcoded calendar URLs, so we can in theory set this
up for ursabot on staging if we really want to.

freenode was also in here, and the calendars were updated to the new
char service, so this was not working becasue of that also. So changed
this too

Signed-off-by: Ryan Lerch <rlerch@redhat.com>