### PR TITLE
Add release cycle to karma messages

### DIFF
--- a/supybot_fedora/plugin.py
+++ b/supybot_fedora/plugin.py
@@ -1040,8 +1040,9 @@ class Fedora(callbacks.Plugin):
 
         irc.reply(
             "Karma for %s has been increased %i times and "
-            "decreased %i times this release cycle for a "
-            "total of %i (%i all time)" % (name, inc, dec, total, alltime_total)
+            "decreased %i times for release cycle %s for a "
+            "total of %i (%i all time)" % (name, inc, dec, release,
+                                           total, alltime_total)
         )
 
     karma = wrap(karma, ["text"])
@@ -1155,7 +1156,7 @@ class Fedora(callbacks.Plugin):
         url = self.registryValue("karma.url")
         irc.reply(
             "Karma for %s changed to %r "
-            "(for the current release cycle):  %s" % (recip, total_this_release, url)
+            "(for the release cycle %s):  %s" % (recip, total_this_release, release, url)
         )
 
     def wikilink(self, irc, msg, args, name):

--- a/supybot_fedora/test.py
+++ b/supybot_fedora/test.py
@@ -65,11 +65,12 @@ class FedoraTestCase(test.ChannelPluginTestCase):
     def testRandom(self):
         self.assertRaises(ValueError)
 
-    def testKarma(self):
+    @mock.patch("supybot_fedora.plugin.Fedora.get_current_release", return_value="f38")
+    def testKarma(self, mock_get_current_release):
         self.instance.users = ["dummy", "test"]
         self.instance.nickmap = {"dummy": "dummy"}
         expected = (
-            "Karma for dummy changed to 1 (for the current release cycle):  "
+            "Karma for dummy changed to 1 (for the release cycle f38):  "
             "https://badges.fedoraproject.org/badge/macaron-cookie-i"
         )
         self.assertResponse("dummy++", expected)


### PR DESCRIPTION
This should help us to spot issue https://github.com/fedora-infra/supybot-fedora/issues/96 more quickly. It will also be clear what release cycle the karma is for.